### PR TITLE
Only allow links when explicitly enabled for the block

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ The table data is saved as a JSON-serialized dictionary with the following keys:
 {
    "headers": [],
    "rows": [],
-   "content": the_sanitised_html
+   "html": the_sanitised_html
 }
 ```
 

--- a/src/wagtail_tinytableblock/blocks.py
+++ b/src/wagtail_tinytableblock/blocks.py
@@ -38,7 +38,7 @@ class TinyTableFieldBlock(FieldBlock):
         try:
             return dict(json.loads(value))
         except (json.decoder.JSONDecodeError, TypeError, ValueError):
-            return html_table_to_dict(value)
+            return html_table_to_dict(value, allow_links=self.meta.allow_links)
 
     def value_for_form(self, value: dict | None) -> str:
         return json.dumps(value)

--- a/src/wagtail_tinytableblock/templates/wagtail_tinytableblock/table_block.html
+++ b/src/wagtail_tinytableblock/templates/wagtail_tinytableblock/table_block.html
@@ -7,7 +7,7 @@
                 {% for header_row in value.data.headers %}
                     <tr>
                         {% for cell in header_row %}
-                            <th{% if cell.scope %} scope="{{ cell.scope }}"{% endif %}{% if cell.colspan %} colspan="{{ cell.colspan }}"{% endif %}{% if cell.rowspan %} rowspan="{{ cell.rowspan }}" {% endif %}>{{ cell.value }}</th>
+                            <th{% if cell.scope %} scope="{{ cell.scope }}"{% endif %}{% if cell.colspan %} colspan="{{ cell.colspan }}"{% endif %}{% if cell.rowspan %} rowspan="{{ cell.rowspan }}" {% endif %}>{{ cell.value|safe }}</th>
                         {% endfor %}
                     </tr>
                 {% endfor %}
@@ -16,7 +16,7 @@
         {% for row in value.data.rows %}
             <tr>
                 {% for cell in row %}
-                    <{{ cell.type }}{% if cell.scope %} scope="{{ cell.scope }}"{% endif %}{% if cell.colspan %} colspan="{{ cell.colspan }}"{% endif %}{% if cell.rowspan %} rowspan="{{ cell.rowspan }}" {% endif %}>{{ cell.value }}</{{ cell.type }}>
+                    <{{ cell.type }}{% if cell.scope %} scope="{{ cell.scope }}"{% endif %}{% if cell.colspan %} colspan="{{ cell.colspan }}"{% endif %}{% if cell.rowspan %} rowspan="{{ cell.rowspan }}" {% endif %}>{{ cell.value|safe }}</{{ cell.type }}>
                 {% endfor %}
             </tr>
         {% endfor %}

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -31,8 +31,8 @@ class BlockTestCase(TestCase):
         self.assertIn(f"<h2>{self.full_data['title']}</h2>", rendered)
         self.assertIn(f"<caption>{self.full_data['caption']}</caption>", rendered)
         self.assertIn("<table>", rendered)
-        self.assertIn("header cell", rendered)
-        self.assertIn("row cell", rendered)
+        self.assertInHTML("<th>header cell</th>", rendered)
+        self.assertInHTML("<td>row cell</td>", rendered)
 
     def test_render_block__no_table(self):
         rendered = self.block.render(self.data_with_empty_table)
@@ -54,3 +54,18 @@ class BlockTestCase(TestCase):
         )
         self.assertIn("<caption>Caption this!</caption>", rendered)
         self.assertNotIn("<h2>", rendered)
+
+    def test_render_block__with_links(self):
+        block = TinyTableBlock(allow_links=True)
+        rendered = block.render(
+            {
+                "data": {
+                    "headers": [
+                        [{"value": '<a href="#">header cell</a>', "type": "th"}]
+                    ],
+                    "rows": [[{"value": '<a href="#">row cell</a>', "type": "td"}]],
+                }
+            }
+        )
+        self.assertInHTML('<a href="#">header cell</a>', rendered)
+        self.assertInHTML('<a href="#">row cell</a>', rendered)


### PR DESCRIPTION
also improves the nh3 cleanup and outputs the cell values as safe.

Ran a number of tests with https://portswigger.net/web-security/cross-site-scripting/cheat-sheet