### PR TITLE
Respect title and target attributes in links

### DIFF
--- a/src/wagtail_tinytableblock/static/wagtail_tinytableblock/js/tiny-table-block.js
+++ b/src/wagtail_tinytableblock/static/wagtail_tinytableblock/js/tiny-table-block.js
@@ -17,7 +17,7 @@ class TinyTableBlockDefinition extends window.wagtailStreamField.blocks.FieldBlo
       plugins += " link autolink";
       toolbar += " | link unlink";
       contextmenu += " link";
-      valid_elements += ",a[href|target|rel]";
+      valid_elements += ",a[href|rel|title|target]";
     }
 
     let contextmenu_never_use_native = true;

--- a/src/wagtail_tinytableblock/utils.py
+++ b/src/wagtail_tinytableblock/utils.py
@@ -23,7 +23,7 @@ def sanitise_html(content: str, *, allow_links: bool = False) -> str:
     }
     if allow_links:
         tags |= {"a"}
-        attributes["a"] = {"href", "rel", "title"}
+        attributes["a"] = {"href", "rel", "title", "target"}
 
     sanitizer = Cleaner(
         tags=tags,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -269,12 +269,14 @@ class UtilsTestCase(TestCase):
                 <tr>
                     <th data-test"foo" valign="middle" colspan="1">Header 1</th>
                     <th class="highlight" align="right">Header 2</th>
+                    <th>Header 3</th>
                 </tr>
             </thead>
             <tbody>
                 <tr>
                     <td rowspan="1"><a href="&#106avascript:alert(1)">Cell <strong>1</strong></a></td>
                     <td><a href="#" click='alert(\\'XSS\\')' rel="next">Cell 2</a></td>
+                    <td><a href="#" target="_blank" rel="noopener" title="Three">Cell 3</a></td>
                 </tr>
             </tbody>
         </table>
@@ -288,12 +290,14 @@ class UtilsTestCase(TestCase):
                 <tr>
                     <th colspan="1">Header 1</th>
                     <th class="highlight" align="right">Header 2</th>
+                    <th>Header 3</th>
                 </tr>
             </thead>
             <tbody>
                 <tr>
                     <td rowspan="1"><a>Cell 1</a></td>
                     <td><a href="#" rel="next">Cell 2</a></td>
+                    <td><a href="#" target="_blank" rel="noopener" title="Three">Cell 3</a></td>
                 </tr>
             </tbody>
         </table>


### PR DESCRIPTION
This PR addresses #23 and ensures that the `title` and `target` attributes are respected when inserting links.

I expanded the existing test to check that both the title and target are not stripped out.

The JavaScript does not have existing tests, so did not introduce any as this would involve making decisions about what to use for testing.